### PR TITLE
+ allow clients to force sync their event cache

### DIFF
--- a/Example/res/layout/main.xml
+++ b/Example/res/layout/main.xml
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
               android:orientation="vertical"
+              android:layout_width="fill_parent"
+              android:layout_height="fill_parent"
+        >
+<LinearLayout android:orientation="vertical"
               android:layout_width="fill_parent"
               android:layout_height="fill_parent"
         >
@@ -72,5 +77,11 @@
             android:layout_height="wrap_content"
             android:text="Add list of common props"
             android:id="@+id/addallpropbutton" android:layout_gravity="left|center_vertical"/>
+    <Button
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Send All Events"
+            android:id="@+id/sendallbutton" android:layout_gravity="left|center_vertical"/>
 </LinearLayout>
 
+</ScrollView>

--- a/Example/src/com/example/app/ExampleActivity.java
+++ b/Example/src/com/example/app/ExampleActivity.java
@@ -137,5 +137,13 @@ public class ExampleActivity extends Activity {
                 Indicative.addProperties(map);
             }
         });
+
+        final Button sendAllEvents = (Button) findViewById(R.id.sendallbutton);
+        sendAllEvents.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                Indicative.sendAllEvents();
+            }
+        });
     }
 }

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,26 @@
+Copyright (c) 2015, Indicative
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met: 
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer. 
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+The views and conclusions contained in the software and documentation are those
+of the authors and should not be interpreted as representing official policies, 
+either expressed or implied, of the FreeBSD Project.


### PR DESCRIPTION
Send up events to the API from client-accessible method.  Do not
disrupt timer that handles events.  Do not record events multiple times.

Resolve #2 .
